### PR TITLE
Add admin Update Dept Name action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ dist
 
 # MacOS
 .DS_Store
+/dump

--- a/README.md
+++ b/README.md
@@ -100,6 +100,26 @@ Authentication information is available anywhere in the Vue frontend via a call 
 User can authenticate using their corporate account.  This is handed via federation in the backend authentication configuration.
 
 
+## Backup and Restore MongoDB
+
+The dev docker-compose file mounts `./dump` into the container at `/dump`, so backup files are accessible from your host machine.
+
+### Backup
+
+```
+docker compose --env-file ./.env.development --file docker-compose.dev.yaml exec mongodb mongodump --username admin --authenticationDatabase admin --db authorities --out /dump
+```
+
+This writes the backup to `./dump/authorities/` on the host.
+
+### Restore
+
+```
+docker compose --env-file ./.env.development --file docker-compose.dev.yaml exec mongodb mongorestore --username admin --authenticationDatabase admin --db authorities --drop /dump/authorities
+```
+
+The `--drop` flag drops existing collections before restoring. Remove it if you want to merge instead.
+
 ## Clearing out the MongoDB collecions from a command line
 
 ```

--- a/api/src/data/departments.json
+++ b/api/src/data/departments.json
@@ -65,7 +65,7 @@
   },
   {
     "dept": "54",
-    "descr": "TOURISM AND CULTURE"
+    "descr": "ECONOMIC DEVELOPMENT, TOURISM AND CULTURE"
   },
   {
     "dept": "55",

--- a/api/src/routes/authorities.ts
+++ b/api/src/routes/authorities.ts
@@ -629,6 +629,19 @@ authoritiesRouter.put(
 
         await db.update(id, req.body);
         await integrationService.checkAuthorityChange({ ...req.body, employee: existing.employee });
+      } else if (save_action == "UpdateDepartmentName") {
+        existing.audit_lines = existing.audit_lines || [];
+
+        existing.audit_lines.push({
+          action: "Updated Department Name",
+          date: new Date(),
+          previous_value: {},
+          user_name: `${req.user.first_name} ${req.user.last_name}`,
+        });
+
+        existing.department_descr = req.body.department_descr;
+
+        await db.update(id, existing);
       }
 
       return res.send("WORKING");

--- a/api/src/routes/form-a-router.ts
+++ b/api/src/routes/form-a-router.ts
@@ -1216,6 +1216,17 @@ formARouter.put(
 
         let item = await loadSinglePosition(req, id);
         return res.json({ data: item });
+      } else if (saveAction == "UpdateDepartmentName") {
+        req.body.audit_lines.push({
+          date: new Date(),
+          user_name: `${req.user.first_name} ${req.user.last_name}`,
+          action: "Updated Department Name",
+          previous_value: existing,
+        });
+
+        await db.update(id, req.body);
+        let item = await loadSinglePosition(req, id);
+        return res.json({ data: item });
       } else if (saveAction == "DMReject") {
         req.body.audit_lines.push({
           date: new Date(),

--- a/web/src/modules/forms/formA/components/formATable.vue
+++ b/web/src/modules/forms/formA/components/formATable.vue
@@ -1,34 +1,26 @@
 <template>
-    <table
-        border="0"
-        cellspacing="0"
-        cellpadding="0"
-        class="table"
-        style="background-color: white; width: 100%; text-align: left"
-    >
+    <table border="0" cellspacing="0" cellpadding="0" class="table"
+        style="background-color: white; width: 100%; text-align: left">
         <thead>
             <tr>
-                <th
-                    :colspan="branchColSpan"
-                    rowspan="3"
-                    style="
+                <th :colspan="branchColSpan" rowspan="3" style="
                         text-align: left;
                         padding: 10px;
                         vertical-align: top;
                         font-weight: 400;
                         width: 60%;
-                    "
-                >
+                    ">
                     <div v-if="branchBundle" style="margin-bottom: 10px">
                         Department:<br />
-                        <strong
-                            >Department Holder {{ branchBundle.data }}
+                        <strong>Department Holder {{ branchBundle.data }}
                         </strong>
                     </div>
                     <div v-else style="margin-bottom: 10px">
                         Department:<br />
                         <strong>{{ formA.department_descr }}</strong>
                     </div>
+                    <v-btn v-if="formA.department_descr === 'TOURISM AND CULTURE' && canAdminister" class="mt-0 mb-5" color="error" small
+                        style="margin-bottom: 10px" @click="$emit('update-department-name')">Update Dept Name</v-btn>
                     <div v-if="branchBundle" style="margin-bottom: 10px">
                         Program:<br />
                         <strong>{{ $route.params.branchName }}</strong>
@@ -60,30 +52,20 @@
                 <th colspan="6" style="height: 20px">
                     SECTION 23 and SECTION 24 ($000)
                 </th>
-                <th
-                    :rowspan="
-                        formA.authority_lines &&
+                <th :rowspan="formA.authority_lines &&
+                    formA.authority_lines.length > 0
+                    ? '2'
+                    : '3'
+                    " class="rotate" :style="formA.authority_lines &&
                         formA.authority_lines.length > 0
-                            ? '2'
-                            : '3'
-                    "
-                    class="rotate"
-                    :style="
-                        formA.authority_lines &&
+                        ? 'border-bottom: none !important;'
+                        : ''
+                        ">
+                    <div class="ml-2 mr-1" :style="formA.authority_lines &&
                         formA.authority_lines.length > 0
-                            ? 'border-bottom: none !important;'
-                            : ''
-                    "
-                >
-                    <div
-                        class="ml-2 mr-1"
-                        :style="
-                            formA.authority_lines &&
-                            formA.authority_lines.length > 0
-                                ? 'margin-bottom: -36px !important'
-                                : ''
-                        "
-                    >
+                        ? 'margin-bottom: -36px !important'
+                        : ''
+                        ">
                         (SECTION 29) <br />
                         CERTIFICATE OF <br />PERFORMANCE
                     </div>
@@ -251,7 +233,7 @@
     </table>
 </template>
 <script>
-// import { mapState} from "vuex";
+import { mapState } from "vuex";
 export default {
     name: "formATable",
     props: {
@@ -278,12 +260,27 @@ export default {
         },
     },
     computed: {
+        ...mapState("home", ["profile"]),
         branchColSpan: function () {
             if (this.branchBundle) {
                 return 3;
             } else {
                 return 2;
             }
+        },
+
+        canAdminister() {
+            if (this.profile && this.profile.roles && this.profile.roles.length > 0) {
+                if (this.profile.roles.includes("System Admin")) return true;
+
+                if (
+                    this.profile.roles.includes("Form A Administrator") &&
+                    this.profile.department_admin_for.includes(this.formA.department_code)
+                )
+                    return true;
+            }
+
+            return false;
         },
     },
     async mounted() {
@@ -297,12 +294,15 @@ export default {
 .table {
     border-collapse: collapse;
 }
+
 .table th {
     text-align: center;
 }
+
 .table thead {
     text-transform: uppercase;
 }
+
 .table th,
 .table td {
     border: 1px black solid;
@@ -315,6 +315,7 @@ export default {
     padding-bottom: 5px;
     max-width: 85px;
 }
+
 table th.bottom {
     white-space: nowrap;
     vertical-align: bottom;
@@ -322,10 +323,11 @@ table th.bottom {
     text-align: left;
 }
 
-.table th.rotate > div {
+.table th.rotate>div {
     transform: rotate(270deg);
     width: 58px;
 }
+
 .table .fb-value {
     width: 80px;
     text-align: center;

--- a/web/src/modules/forms/formA/views/PositionDetails.vue
+++ b/web/src/modules/forms/formA/views/PositionDetails.vue
@@ -4,9 +4,8 @@
 
     <BaseCard :showHeader="true" heading="Delegation of Financial Signing Authority">
       <template slot="right">
-        <v-chip color="#f2a900" v-if="formA.is_deputy_minister || formA.is_deputy_duplicate" class="mr-4" dark
-          >Deputy Minister or Equivalent</v-chip
-        >
+        <v-chip color="#f2a900" v-if="formA.is_deputy_minister || formA.is_deputy_duplicate" class="mr-4" dark>Deputy
+          Minister or Equivalent</v-chip>
         <form-a-status :isLocked="isLocked" :status="status"> </form-a-status>
 
         <actions-menu :showPreview="showPreview" :showDMApprove="showDMApprove" :showDMLock="showDMLock"></actions-menu>
@@ -15,7 +14,7 @@
 
       <v-card class="default">
         <v-card-text>
-          <formATable :formA="formA"></formATable>
+          <formATable :formA="formA" @update-department-name="updateDepartmentName"></formATable>
         </v-card-text>
       </v-card>
 
@@ -24,17 +23,11 @@
           <v-card class="default">
             <v-card-title>Related Form B Authorizations</v-card-title>
             <v-card-text>
-              <v-data-table
-                dense
-                :headers="[
-                  { text: 'Name', value: 'employee.name' },
-                  { text: 'Title', value: 'employee.title' },
-                  { text: 'Status', value: 'status' },
-                ]"
-                :items="formA.active_authorities"
-                @click:row="openFormB"
-                class="row-clickable"
-              />
+              <v-data-table dense :headers="[
+                { text: 'Name', value: 'employee.name' },
+                { text: 'Title', value: 'employee.title' },
+                { text: 'Status', value: 'status' },
+              ]" :items="formA.active_authorities" @click:row="openFormB" class="row-clickable" />
             </v-card-text>
           </v-card>
         </v-col>
@@ -42,17 +35,11 @@
           <v-card class="default">
             <v-card-title>Audit History</v-card-title>
             <v-card-text>
-              <v-data-table
-                dense
-                :headers="[
-                  { text: 'Date', value: 'date_display' },
-                  { text: 'User', value: 'user_name' },
-                  { text: 'Action', value: 'action' },
-                ]"
-                :items="formA.audit_lines"
-                :sort-by="['date']"
-                :sort-desc="[true]"
-              />
+              <v-data-table dense :headers="[
+                { text: 'Date', value: 'date_display' },
+                { text: 'User', value: 'user_name' },
+                { text: 'Action', value: 'action' },
+              ]" :items="formA.audit_lines" :sort-by="['date']" :sort-desc="[true]" />
             </v-card-text>
           </v-card>
         </v-col>
@@ -67,30 +54,19 @@
       </v-app-bar>
       <v-card tile>
         <v-card-text class="pt-3">
-          <p>When this position is approved, a Form B is automatically generated. Please select the person to assign to this position.</p>
-          <employee-lookup
-            actionName="Select"
-            label="Deputy Minister or Equivalent for new Form B: "
-            :select="pickEmployee"
-            v-if="!activateEmployee.email"
-          ></employee-lookup>
+          <p>When this position is approved, a Form B is automatically generated. Please select the person to assign to
+            this
+            position.</p>
+          <employee-lookup actionName="Select" label="Deputy Minister or Equivalent for new Form B: "
+            :select="pickEmployee" v-if="!activateEmployee.email"></employee-lookup>
 
-          <v-text-field
-            v-model="activateEmployee.display_name"
-            readonly
-            dense
-            outlined
-            label="Deputy Minister or Equivalent for new Form B"
-            append-icon="mdi-lock"
-            v-if="activateEmployee.email"
-            append-outer-icon="mdi-close-circle"
-            @click:append-outer="unselectEmployee"
-          ></v-text-field>
+          <v-text-field v-model="activateEmployee.display_name" readonly dense outlined
+            label="Deputy Minister or Equivalent for new Form B" append-icon="mdi-lock" v-if="activateEmployee.email"
+            append-outer-icon="mdi-close-circle" @click:append-outer="unselectEmployee"></v-text-field>
           <p>Department of Finance Administrators will receive an email notification when you complete this step.</p>
 
-          <v-btn @click="dmLockClick" :disabled="!activateEmployee.display_name" color="primary" class="mb-0 mr-5"
-            >Lock</v-btn
-          >
+          <v-btn @click="dmLockClick" :disabled="!activateEmployee.display_name" color="primary"
+            class="mb-0 mr-5">Lock</v-btn>
         </v-card-text>
       </v-card>
     </v-dialog>
@@ -254,6 +230,12 @@ export default {
     },
     pickEmployee(item) {
       this.activateEmployee = item;
+    },
+    async updateDepartmentName() {
+      if (!confirm('This will update this Position\'s Department from "TOURISM AND CULTURE" to "ECONOMIC DEVELOPMENT, TOURISM AND CULTURE". This action cannot be undone. Would you like to continue?')) return;
+      this.formA.department_descr = "ECONOMIC DEVELOPMENT, TOURISM AND CULTURE";
+      this.formA.save_action = "UpdateDepartmentName";
+      await this.saveFormA(this.formA);
     },
   },
 };

--- a/web/src/modules/forms/formB/components/tableLayouts/delegateInfo.vue
+++ b/web/src/modules/forms/formB/components/tableLayouts/delegateInfo.vue
@@ -8,7 +8,9 @@
     <br /><br />
 
     Department:<br />
-    <strong>{{ formB.department_descr }}</strong>
+    <strong>{{ formB.department_descr }}</strong><br />
+    <v-btn v-if="formB.department_descr === 'TOURISM AND CULTURE' && canAdminister" color="error" small class="mb-0"
+      @click="updateDepartmentName">Update Dept Name</v-btn>
     <br /><br />
     Program:<br />
     <strong>{{ formB.program_branch }}</strong>
@@ -22,11 +24,37 @@
 </template>
 
 <script>
-import { mapState } from "vuex";
+import { mapState, mapActions } from "vuex";
 export default {
   name: "delegateInfo",
   computed: {
     ...mapState("authority/formB", ["formB"]),
+    ...mapState("home", ["profile"]),
+
+    canAdminister() {
+      if (this.profile && this.profile.roles && this.profile.roles.length > 0) {
+        if (this.profile.roles.includes("System Admin")) return true;
+
+        if (
+          this.profile.roles.includes("Form B Administrator") &&
+          this.profile.department_admin_for.includes(this.formB.department_code)
+        )
+          return true;
+      }
+
+      return false;
+    },
+  },
+  methods: {
+    ...mapActions("authority/formB", ["saveFormB", "loadFormB"]),
+
+    async updateDepartmentName() {
+      if (!confirm('This will update this Form B\'s Department from "TOURISM AND CULTURE" to "ECONOMIC DEVELOPMENT, TOURISM AND CULTURE". This action cannot be undone. Would you like to continue?')) return;
+      this.formB.department_descr = "ECONOMIC DEVELOPMENT, TOURISM AND CULTURE";
+      this.formB.save_action = "UpdateDepartmentName";
+      await this.saveFormB(this.formB);
+      await this.loadFormB(this.formB._id);
+    },
   },
 };
 </script>


### PR DESCRIPTION
Add an admin-only "Update Dept Name" button and handler for Form A and Form B. Permissions check (canAdminister) uses the user's profile roles (System Admin or Form A/B Administrator with department_admin_for). For Form A the button is emitted from formATable.vue and handled in PositionDetails.vue (updateDepartmentName) which prompts confirmation, updates department_descr to "ECONOMIC DEVELOPMENT, TOURISM AND CULTURE", sets save_action and calls saveFormA. For Form B delegateInfo.vue a similar button and updateDepartmentName method were added that calls saveFormB and reloads the form. Also include small template/formatting and import adjustments (mapState/mapActions) and minor CSS/layout tidy-ups.

Add MongoDB backup and restore instructions

Add a "Backup and Restore MongoDB" section to the README describing how the dev docker-compose mounts ./dump to /dump and providing example mongodump and mongorestore commands using the development compose file and .env.development. Notes that backups are written to ./dump/authorities/ on the host and that the restore example uses --drop to replace existing collections (remove --drop to merge).

Add UpdateDepartmentName audit handling

Record department name updates and return updated position data. Added UpdateDepartmentName handling in authorities and form-a-router to append an audit_lines entry (action, date, user_name and previous_value) and persist the changed department description. In authorities.ts the existing record is updated with a new audit line and department_descr before saving; in form-a-router.ts the request body receives an audit line, the record is updated, and the updated item is returned. Also updated departments.json entry for dept 54 to "ECONOMIC DEVELOPMENT, TOURISM AND CULTURE".

Ignore dump directory in .gitignore

Add /dump to .gitignore to avoid committing dump/database export files. Also normalize EOF newline for .DS_Store entry.