### PR TITLE
Add signer name column to Form A signatures; fix header overflow

### DIFF
--- a/api/src/templates/pdf/FormATemplate.html
+++ b/api/src/templates/pdf/FormATemplate.html
@@ -110,15 +110,16 @@
       }
 
       .table th.rotate {
-        height: 140px;
+        height: 150px;
         white-space: nowrap;
         vertical-align: bottom;
-        padding-bottom: 20px;
+        padding-bottom: 17px;
       }
 
       .table th.rotate > div {
         transform: rotate(270deg);
         width: 48px;
+        line-height: 1.15;
       }
 
       .table .fb-value {
@@ -178,7 +179,7 @@
               padding: 10px;
               vertical-align: top;
               width: 400px;
-              height: 190px;
+              height: 130px;
             "
           >
             Department:<br />
@@ -194,9 +195,9 @@
           >
             SPENDING AUTHORITY
           </th>
-          <th rowspan="4" class="rotate" style="height: 140px">
+          <th rowspan="4" class="rotate" style="height: 150px">
             <div>
-              PAYMENT AUTHORITY (SECTION <br />30)
+              Payment Authority<br />(Section 30)
               <span style="font-size: 9px">REQUISITION FOR PAYMENT</span>
             </div>
           </th>
@@ -218,13 +219,13 @@
             <div>Contracts for<br />Goods or Services</div>
           </th>
           <th rowspan="2" class="rotate">
-            <div>Loans & Guarantees</div>
+            <div>Loans &amp;<br />Guarantees</div>
           </th>
           <th rowspan="2" class="rotate">
-            <div>Transfer Payments</div>
+            <div>Transfer<br />Payments</div>
           </th>
           <th rowspan="2" class="rotate">
-            <div>Authorization for Travel</div>
+            <div>Authorization<br />for Travel</div>
           </th>
           <th rowspan="2" class="rotate">
             <div>Request for Goods<br />or Services</div>
@@ -275,10 +276,10 @@
         </td>
       </tr>
       <tr style="min-height: 120px; break-inside: avoid">
-        <td style="width: 40%; vertical-align: top; font-size: 11px">
-          <br /><br /><br />NL = No limit
+        <td style="width: 15%; vertical-align: bottom; font-size: 11px; padding-bottom: 3px">
+          NL = No limit
         </td>
-        <td style="width: 60%; vertical-align: top; font-size: 11px">
+        <td style="width: 85%; vertical-align: top; font-size: 11px">
           <div style="height: 100%">
             <table
               style="width: 100%; margin: 0 0 0 5px"
@@ -289,7 +290,7 @@
               <tr>
                 <td
                   style="
-                    width: 150px;
+                    width: 100px;
                     padding-top: 10px;
                     text-align: right;
                     padding-right: 7px;
@@ -299,26 +300,38 @@
                 </td>
                 <td
                   style="
-                    width: 50%;
+                    width: 33%;
                     vertical-align: bottom;
                     padding-bottom: 3px;
                     padding-top: 25px;
                   "
                 >
-                  <div style="border-top: 1px black solid; width: 80%">
+                  <div style="border-top: 1px black solid; width: 90%">
+                    Departmental Administrator Name
+                  </div>
+                </td>
+                <td
+                  style="
+                    width: 33%;
+                    vertical-align: bottom;
+                    padding-bottom: 3px;
+                    padding-top: 25px;
+                  "
+                >
+                  <div style="border-top: 1px black solid; width: 90%">
                     Date
                   </div>
                 </td>
                 <td
                   style="
-                    width: 50%;
+                    width: 34%;
                     vertical-align: bottom;
                     padding-bottom: 3px;
                     padding-top: 25px;
                   "
                 >
-                  <div style="border-top: 1px black solid; width: 80%">
-                    Departmental Administrator
+                  <div style="border-top: 1px black solid; width: 90%">
+                    Departmental Administrator Signature
                   </div>
                 </td>
               </tr>
@@ -334,26 +347,38 @@
                 </td>
                 <td
                   style="
-                    width: 50%;
+                    width: 33%;
                     vertical-align: bottom;
                     padding-bottom: 3px;
                     padding-top: 50px;
                   "
                 >
-                  <div style="border-top: 1px black solid; width: 80%">
+                  <div style="border-top: 1px black solid; width: 90%">
+                    Deputy Minister Name
+                  </div>
+                </td>
+                <td
+                  style="
+                    width: 33%;
+                    vertical-align: bottom;
+                    padding-bottom: 3px;
+                    padding-top: 50px;
+                  "
+                >
+                  <div style="border-top: 1px black solid; width: 90%">
                     Date
                   </div>
                 </td>
                 <td
                   style="
-                    width: 50%;
+                    width: 34%;
                     vertical-align: bottom;
                     padding-bottom: 3px;
                     padding-top: 50px;
                   "
                 >
-                  <div style="border-top: 1px black solid; width: 80%">
-                    Deputy Minister
+                  <div style="border-top: 1px black solid; width: 90%">
+                    Deputy Minister Signature
                   </div>
                 </td>
               </tr>

--- a/api/src/templates/pdf/FormATemplateDraft.html
+++ b/api/src/templates/pdf/FormATemplateDraft.html
@@ -123,15 +123,16 @@
       }
 
       .table th.rotate {
-        height: 140px;
+        height: 150px;
         white-space: nowrap;
         vertical-align: bottom;
-        padding-bottom: 20px;
+        padding-bottom: 17px;
       }
 
       .table th.rotate > div {
         transform: rotate(270deg);
         width: 48px;
+        line-height: 1.15;
       }
 
       .table .fb-value {
@@ -191,7 +192,7 @@
               padding: 10px;
               vertical-align: top;
               width: 400px;
-              height: 190px;
+              height: 130px;
             "
           >
             Department:<br />
@@ -207,9 +208,9 @@
           >
             SPENDING AUTHORITY
           </th>
-          <th rowspan="4" class="rotate" style="height: 140px">
+          <th rowspan="4" class="rotate" style="height: 150px">
             <div>
-              PAYMENT AUTHORITY (SECTION <br />30)
+              Payment Authority<br />(Section 30)
               <span style="font-size: 9px">REQUISITION FOR PAYMENT</span>
             </div>
           </th>
@@ -231,13 +232,13 @@
             <div>Contracts for<br />Goods or Services</div>
           </th>
           <th rowspan="2" class="rotate">
-            <div>Loans & Guarantees</div>
+            <div>Loans &amp;<br />Guarantees</div>
           </th>
           <th rowspan="2" class="rotate">
-            <div>Transfer Payments</div>
+            <div>Transfer<br />Payments</div>
           </th>
           <th rowspan="2" class="rotate">
-            <div>Authorization for Travel</div>
+            <div>Authorization<br />for Travel</div>
           </th>
           <th rowspan="2" class="rotate">
             <div>Request for Goods<br />or Services</div>
@@ -288,10 +289,10 @@
         </td>
       </tr>
       <tr style="min-height: 120px; break-inside: avoid">
-        <td style="width: 40%; vertical-align: top; font-size: 11px">
-          <br /><br /><br />NL = No limit
+        <td style="width: 15%; vertical-align: bottom; font-size: 11px; padding-bottom: 3px">
+          NL = No limit
         </td>
-        <td style="width: 60%; vertical-align: top; font-size: 11px">
+        <td style="width: 85%; vertical-align: top; font-size: 11px">
           <div style="height: 100%">
             <table
               style="width: 100%; margin: 0 0 0 5px"
@@ -302,7 +303,7 @@
               <tr>
                 <td
                   style="
-                    width: 150px;
+                    width: 100px;
                     padding-top: 10px;
                     text-align: right;
                     padding-right: 7px;
@@ -312,26 +313,38 @@
                 </td>
                 <td
                   style="
-                    width: 50%;
+                    width: 33%;
                     vertical-align: bottom;
                     padding-bottom: 3px;
                     padding-top: 25px;
                   "
                 >
-                  <div style="border-top: 1px black solid; width: 80%">
+                  <div style="border-top: 1px black solid; width: 90%">
+                    Departmental Administrator Name
+                  </div>
+                </td>
+                <td
+                  style="
+                    width: 33%;
+                    vertical-align: bottom;
+                    padding-bottom: 3px;
+                    padding-top: 25px;
+                  "
+                >
+                  <div style="border-top: 1px black solid; width: 90%">
                     Date
                   </div>
                 </td>
                 <td
                   style="
-                    width: 50%;
+                    width: 34%;
                     vertical-align: bottom;
                     padding-bottom: 3px;
                     padding-top: 25px;
                   "
                 >
-                  <div style="border-top: 1px black solid; width: 80%">
-                    Departmental Administrator
+                  <div style="border-top: 1px black solid; width: 90%">
+                    Departmental Administrator Signature
                   </div>
                 </td>
               </tr>
@@ -347,26 +360,38 @@
                 </td>
                 <td
                   style="
-                    width: 50%;
+                    width: 33%;
                     vertical-align: bottom;
                     padding-bottom: 3px;
                     padding-top: 50px;
                   "
                 >
-                  <div style="border-top: 1px black solid; width: 80%">
+                  <div style="border-top: 1px black solid; width: 90%">
+                    Deputy Minister Name
+                  </div>
+                </td>
+                <td
+                  style="
+                    width: 33%;
+                    vertical-align: bottom;
+                    padding-bottom: 3px;
+                    padding-top: 50px;
+                  "
+                >
+                  <div style="border-top: 1px black solid; width: 90%">
                     Date
                   </div>
                 </td>
                 <td
                   style="
-                    width: 50%;
+                    width: 34%;
                     vertical-align: bottom;
                     padding-bottom: 3px;
                     padding-top: 50px;
                   "
                 >
-                  <div style="border-top: 1px black solid; width: 80%">
-                    Deputy Minister
+                  <div style="border-top: 1px black solid; width: 90%">
+                    Deputy Minister Signature
                   </div>
                 </td>
               </tr>


### PR DESCRIPTION
## Summary
- Adds a **Name** column next to Date/Signature in the Form A signature block for both Departmental Administrator and Deputy Minister rows.
- Narrowed the "NL = No limit" legend column and moved the text to the bottom so the three signature fields get more gutter.
- Reworked the rotated column headers: tighter `line-height`, explicit line breaks on the long labels (`Loans & Guarantees`, `Transfer Payments`, `Authorization for Travel`, `Payment Authority (Section 30)`), and a shorter Department cell so the rotated text no longer overflows into the **SPENDING AUTHORITY** row.
- Applied identically to `FormATemplate.html` and `FormATemplateDraft.html`.

## Test plan
- [ ] Generate a Form A PDF and verify rotated column headers fit within their cells (no text spilling into the Spending Authority / Section 23 rows).
- [ ] Verify the signature block renders with three columns (Name / Date / Signature) for both Recommended and Approved rows.
- [ ] Generate a draft Form A PDF and confirm the same changes are reflected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)